### PR TITLE
github crawler: repository support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,9 @@ Monocle purpose is to provide metrics about Changes through a web API and a web 
 
 ## Deploy the master version
 
-Monocle is an early phase of developement. The process below will help you to index Pull Requests events of a Github organization and to start the web UI to browse metrics using `docker-compose`.
+Monocle is in an early phase of developement. Feedback is highly welcome.
+
+The process below describes how to index changes from a Github repository, a full Github organisation and Gerrit repositories, and then how to start the web UI to browse metrics using `docker-compose`.
 
 ### Clone and prepare data directory
 
@@ -30,9 +32,18 @@ projects:
       loop_delay: 10
       github_orgs:
         - name: tektoncd
+          repository: pipeline
           updated_since: "2020-03-15"
           token: <github_token>
           base_url: https://github.com
+        - name: spinnaker
+          updated_since: "2020-03-15"
+          token: <github_token>
+          base_url: https://github.com
+      gerrit_repositories:
+        - name: ^zuul/.*
+          updated_since: "2020-03-15 00:00:00"
+          base_url: https://review.opendev.org
 ```
 
 ### Start docker-compose

--- a/monocle/main.py
+++ b/monocle/main.py
@@ -133,6 +133,7 @@ def main():
                     updated_since=crawler_item['updated_since'],
                     loop_delay=project['crawler']['loop_delay'],
                     token=crawler_item['token'],
+                    repository=crawler_item.get('repository'),
                     base_url=crawler_item['base_url'])
                 tpool.append(Crawler(c_args, elastic_conn=args.elastic_conn,
                                      elastic_timeout=args.elastic_timeout))

--- a/monocle/projects.py
+++ b/monocle/projects.py
@@ -43,6 +43,11 @@ schema = {
                     "description": "The organization name",
                     "type": "string",
                 },
+                "repository": {
+                    "description":
+                        "The repository name within the organization",
+                    "type": "string",
+                },
                 "updated_since": {
                     "description":
                         "The change updated since date (YYYY-mm-dd)",


### PR DESCRIPTION
This patch adds a new repository parameter in the crawler
definition for a Github. It then possible to select the repositories
we want to fetch data from instead of the full organization.