### PR TITLE
Improve tops authors

### DIFF
--- a/monocle/db/queries.py
+++ b/monocle/db/queries.py
@@ -197,11 +197,7 @@ def _events_top(es, index, repository_fullname, field, params):
     body = {
         "aggs": {
             "agg1": {
-                "terms": {
-                    "field": field,
-                    "size": params['size'],
-                    "order": {"_count": "desc"},
-                }
+                "terms": {"field": field, "size": 1000, "order": {"_count": "desc"},}
             }
         },
         "size": 0,
@@ -211,11 +207,15 @@ def _events_top(es, index, repository_fullname, field, params):
     count_series = [b['doc_count'] for b in data['aggregations']['agg1']['buckets']]
     count_avg = statistics.mean(count_series) if count_series else 0
     count_median = statistics.median(sorted(count_series)) if count_series else 0
+    _from = params['from']
+    _to = params['from'] + params['size']
+    buckets = data['aggregations']['agg1']['buckets']
     return {
-        'items': data['aggregations']['agg1']['buckets'],
+        'items': buckets[_from:_to],
         'count_avg': count_avg,
         'count_median': count_median,
-        'total': data['hits']['total'],
+        'total': len(buckets),
+        'total_hits': data['hits']['total'],
     }
 
 

--- a/monocle/db/queries.py
+++ b/monocle/db/queries.py
@@ -197,7 +197,7 @@ def _events_top(es, index, repository_fullname, field, params):
     body = {
         "aggs": {
             "agg1": {
-                "terms": {"field": field, "size": 1000, "order": {"_count": "desc"},}
+                "terms": {"field": field, "size": 1000, "order": {"_count": "desc"}}
             }
         },
         "size": 0,
@@ -261,6 +261,12 @@ def authors_top_reviewed(es, index, repository_fullname, params):
 def authors_top_commented(es, index, repository_fullname, params):
     params = deepcopy(params)
     params['etype'] = ("ChangeCommentedEvent",)
+    return _events_top(es, index, repository_fullname, "on_author", params)
+
+
+def authors_top_merged(es, index, repository_fullname, params):
+    params = deepcopy(params)
+    params['etype'] = ("ChangeMergedEvent",)
     return _events_top(es, index, repository_fullname, "on_author", params)
 
 
@@ -559,6 +565,10 @@ def most_active_authors_stats(es, index, repository_fullname, params):
     for etype in ("ChangeCreatedEvent", "ChangeReviewedEvent", "ChangeCommentedEvent"):
         params['etype'] = (etype,)
         ret[etype] = events_top_authors(es, index, repository_fullname, params)
+    switch_to_on_authors(params)
+    ret["ChangeMergedEvent"] = authors_top_merged(
+        es, index, repository_fullname, params
+    )
     return ret
 
 

--- a/web/src/components/top.js
+++ b/web/src/components/top.js
@@ -17,8 +17,8 @@ import {
 } from './common'
 
 class TopEventsTable extends React.Component {
-  rowStyleFormat (median, value) {
-    if (value >= median) {
+  rowStyleFormat (average, value) {
+    if (value >= average) {
       return { color: 'green' }
     }
   }
@@ -43,7 +43,7 @@ class TopEventsTable extends React.Component {
                 <tbody>
                   {this.props.data.items.map((x, index) =>
                     <tr key={index}>
-                      <td style={this.rowStyleFormat(this.props.data.count_median, x.doc_count)}>{index + 1}</td>
+                      <td style={this.rowStyleFormat(this.props.data.count_avg, x.doc_count)}>{index + 1}</td>
                       <td><a href={addUrlField('authors', x.key)}>{x.key}</a></td>
                       <td>{x.doc_count}</td>
                     </tr>)}
@@ -61,7 +61,7 @@ TopEventsTable.propTypes = {
   title: PropTypes.string.isRequired,
   data: PropTypes.shape({
     items: PropTypes.array,
-    count_median: PropTypes.number
+    count_avg: PropTypes.number
   })
 }
 

--- a/web/src/components/top.js
+++ b/web/src/components/top.js
@@ -92,13 +92,13 @@ class MostActiveAuthorsStats extends BaseQueryComponent {
                   <Col>
                     <TopEventsTable
                       data={data.ChangeCreatedEvent}
-                      title="By changes created"
+                      title="By Created Changes"
                     />
                   </Col>
                   <Col>
                     <TopEventsTable
                       data={data.ChangeMergedEvent}
-                      title="By changes merged"
+                      title="By Merged Changes"
                     />
                   </Col>
                 </Row>
@@ -107,13 +107,13 @@ class MostActiveAuthorsStats extends BaseQueryComponent {
                   <Col>
                     <TopEventsTable
                       data={data.ChangeReviewedEvent}
-                      title="By changes reviewed"
+                      title="By Reviewed Changes"
                     />
                   </Col>
                   <Col>
                     <TopEventsTable
                       data={data.ChangeCommentedEvent}
-                      title="By changes commented"
+                      title="By Commented Changes"
                     />
                   </Col>
                 </Row>

--- a/web/src/components/top.js
+++ b/web/src/components/top.js
@@ -92,19 +92,28 @@ class MostActiveAuthorsStats extends BaseQueryComponent {
                   <Col>
                     <TopEventsTable
                       data={data.ChangeCreatedEvent}
-                      title="Changes"
+                      title="By changes created"
+                    />
+                  </Col>
+                  <Col>
+                    <TopEventsTable
+                      data={data.ChangeMergedEvent}
+                      title="By changes merged"
+                    />
+                  </Col>
+                </Row>
+                <Row><Col><p></p></Col></Row>
+                <Row>
+                  <Col>
+                    <TopEventsTable
+                      data={data.ChangeReviewedEvent}
+                      title="By changes reviewed"
                     />
                   </Col>
                   <Col>
                     <TopEventsTable
                       data={data.ChangeCommentedEvent}
-                      title="Comments"
-                    />
-                  </Col>
-                  <Col>
-                    <TopEventsTable
-                      data={data.ChangeReviewedEvent}
-                      title="Reviews"
+                      title="By changes commented"
                     />
                   </Col>
                 </Row>


### PR DESCRIPTION
This PR adds:
- events_tops pagination support
- add ChangeMergedEvents support in Changes lifecycle stats
- Move from median to average from green top (and increase fiability)