### PR TITLE
crawler: solidify github process

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,5 @@ web
 data
 docker-compose.yml
 contrib
+dump
+etc

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The process below describes how to index changes from a Github repository, a ful
 ```Shell
 $ git clone https://github.com/morucci/monocle.git
 $ cd monocle
-$ mkdir data etc
+$ mkdir data etc dump
 ```
 
 ### Create the projects.yaml file

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
     command: monocle --elastic-conn elastic:9200 crawler --config /etc/projects.yaml
     volumes:
       - $PWD/etc:/etc:Z
+      - $PWD/dump:/var/lib/crawler:Z
   web:
     build: web
     depends_on:

--- a/monocle/crawler.py
+++ b/monocle/crawler.py
@@ -100,18 +100,18 @@ class Runner(object):
             log.info("%d objects will be updated in the database" % len(objects))
             self.db.update(objects)
 
-    def run(self):
-        while True:
-            self.run_step()
-            log.info("Waiting %s seconds before next fetch ..." % (self.loop_delay))
-            sleep(self.loop_delay)
-
 
 class Crawler(Thread, Runner):
     def __init__(self, args, elastic_conn='localhost:9200', elastic_timeout=10):
         Runner.__init__(self, args, elastic_conn, elastic_timeout)
         Thread.__init__(self)
+
+    def run(self):
         self.setName(self.repository_el_re)
+        while True:
+            self.run_step()
+            log.info("Waiting %s seconds before next fetch ..." % (self.loop_delay))
+            sleep(self.loop_delay)
 
 
 class GroupCrawler(Thread):

--- a/monocle/gerrit/review.py
+++ b/monocle/gerrit/review.py
@@ -112,7 +112,7 @@ class ReviewesFetcher(object):
                 break
         return reviews
 
-    def extract_objects(self, reviewes):
+    def extract_objects(self, reviewes, dumper):
         def timedelta(start, end):
             format = "%Y-%m-%dT%H:%M:%SZ"
             start = datetime.strptime(start, format)
@@ -306,6 +306,7 @@ class ReviewesFetcher(object):
                 objects.extend(extract_pr_objects(review))
             except Exception:
                 self.log.exception("Unable to extract Review data: %s" % review)
+                dumper(review, 'gerrit_')
         return objects
 
 

--- a/monocle/github/graphql.py
+++ b/monocle/github/graphql.py
@@ -26,6 +26,8 @@ import requests
 from time import sleep
 from datetime import datetime
 
+from tenacity import retry, stop_after_attempt, wait_fixed
+
 
 class GithubGraphQLQuery(object):
 
@@ -77,6 +79,7 @@ class GithubGraphQLQuery(object):
         data = self.query(qdata, skip_get_rate_limit=True)
         return data['data']['rateLimit']
 
+    @retry(stop=stop_after_attempt(6), wait=wait_fixed(10))
     def query(self, qdata, skip_get_rate_limit=False, ignore_not_found=False):
         if not skip_get_rate_limit:
             if self.query_count % self.get_rate_limit_rate == 0:

--- a/monocle/github/pullrequest.py
+++ b/monocle/github/pullrequest.py
@@ -20,9 +20,7 @@
 # SOFTWARE.
 
 
-import json
 import logging
-import tempfile
 import requests
 from datetime import datetime
 from time import sleep
@@ -269,7 +267,7 @@ class PRsFetcher(object):
         raw = self.gql.query(qdata % kwargs)['data']['repository']['pullRequest']
         return (raw, self.extract_objects([raw]))
 
-    def extract_objects(self, prs, dump_dir=None):
+    def extract_objects(self, prs, dumper):
         def get_login(data):
             if data and 'login' in data and data['login']:
                 return data['login']
@@ -410,38 +408,19 @@ class PRsFetcher(object):
                 objects.append(obj)
             return objects
 
-        def dump_data(data, prefix=None):
-            try:
-                if dump_dir:
-                    tmpfile = tempfile.NamedTemporaryFile(
-                        dir=dump_dir,
-                        prefix=prefix,
-                        suffix='.json',
-                        mode='w',
-                        delete=False,
-                    )
-                    json.dump(data, tmpfile)
-                    tmpfile.close()
-                    self.log.info('PR dumped to %s' % tmpfile.name)
-                    return tmpfile.name
-            except Exception:
-                self.log.exception('Unable to dump data')
-            return None
-
         objects = []
-        idx = 0
         for pr in prs:
-            idx += 1
             try:
                 objects.extend(extract_pr_objects(pr))
             except Exception:
                 self.log.expection('Unable to extract PR')
-                dump_data(pr)
+                dumper(pr, 'github_')
         return objects
 
 
 if __name__ == '__main__':
     import os
+    import json
     import argparse
     from pprint import pprint
     from monocle.github import graphql

--- a/monocle/github/pullrequest.py
+++ b/monocle/github/pullrequest.py
@@ -31,6 +31,13 @@ name = 'github_crawler'
 help = 'Github Crawler to fetch PRs events'
 
 
+class ExtractPRIssue(Exception):
+    def __init__(self, excpt, pr, idx=-1):
+        self.excpt = excpt
+        self.pr = pr
+        self.idx = idx
+
+
 @dataclass
 class GithubCrawlerArgs(object):
     updated_since: str
@@ -195,6 +202,9 @@ class PRsFetcher(object):
         if not kwargs['total_prs_count']:
             kwargs['total_prs_count'] = data['data']['search']['issueCount']
             self.log.info("Total PRs to fetch: %s" % kwargs['total_prs_count'])
+        if 'data' not in data:
+            self.log.error('No data collected: %s' % data)
+            return False
         for pr in data['data']['search']['edges']:
             prs.append(pr['node'])
         pageInfo = data['data']['search']['pageInfo']
@@ -258,6 +268,11 @@ class PRsFetcher(object):
         return (raw, self.extract_objects([raw]))
 
     def extract_objects(self, prs):
+        def get_login(data):
+            if data and 'login' in data and data['login']:
+                return data['login']
+            return 'ghost'
+
         def timedelta(start, end):
             format = "%Y-%m-%dT%H:%M:%SZ"
             start = datetime.strptime(start, format)
@@ -284,9 +299,9 @@ class PRsFetcher(object):
             change['type'] = 'Change'
             change['id'] = pr['id']
             change['number'] = pr['number']
-            change['repository_prefix'] = pr['repository']['owner']['login']
+            change['repository_prefix'] = get_login(pr['repository']['owner'])
             change['repository_fullname'] = "%s/%s" % (
-                pr['repository']['owner']['login'],
+                get_login(pr['repository']['owner']),
                 pr['repository']['name'],
             )
             change['repository_shortname'] = pr['repository']['name']
@@ -299,7 +314,7 @@ class PRsFetcher(object):
                 change['repository_fullname'],
                 change['number'],
             )
-            change['author'] = pr['author']['login']
+            change['author'] = get_login(pr['author'])
             change['branch'] = pr['headRefName']
             change['target_branch'] = pr['baseRefName']
             change['title'] = pr['title']
@@ -317,7 +332,7 @@ class PRsFetcher(object):
             ]
             change['commit_count'] = len(pr['commits']['edges'])
             if pr['mergedBy']:
-                change['merged_by'] = pr['mergedBy']['login']
+                change['merged_by'] = get_login(pr['mergedBy'])
             else:
                 change['merged_by'] = None
             change['updated_at'] = pr['updatedAt']
@@ -335,7 +350,7 @@ class PRsFetcher(object):
                 map(lambda n: n['node']['name'], pr['labels']['edges'])
             )
             change['assignees'] = list(
-                map(lambda n: n['node']['login'], pr['assignees']['edges'])
+                map(lambda n: get_login(n['node']), pr['assignees']['edges'])
             )
             objects.append(change)
             obj = {
@@ -352,20 +367,22 @@ class PRsFetcher(object):
                     'type': 'ChangeCommentedEvent',
                     'id': _comment['id'],
                     'created_at': _comment['createdAt'],
-                    'author': _comment['author']['login'],
+                    'author': get_login(_comment['author']),
                 }
                 insert_change_attributes(obj, change)
                 objects.append(obj)
             for timelineitem in pr['timelineItems']['edges']:
                 _timelineitem = timelineitem['node']
+                _author = _timelineitem.get('actor', {}) or _timelineitem.get(
+                    'author', {}
+                )
+                if not _author:
+                    _author = {'login': 'ghost'}
                 obj = {
                     'type': self.events_map[_timelineitem['__typename']],
                     'id': _timelineitem['id'],
                     'created_at': _timelineitem['createdAt'],
-                    'author': (
-                        _timelineitem.get('actor', {}).get('login')
-                        or _timelineitem.get('author', {}).get('login')
-                    ),
+                    'author': _author.get('login'),
                 }
                 insert_change_attributes(obj, change)
                 if 'state' in _timelineitem:
@@ -386,17 +403,19 @@ class PRsFetcher(object):
                     'created_at': _commit.get('pushedDate', change['created_at']),
                 }
                 if _commit['author'].get('user'):
-                    obj['author'] = _commit['author']['user'].get('login')
+                    obj['author'] = get_login(_commit['author']['user'])
                 insert_change_attributes(obj, change)
                 objects.append(obj)
             return objects
 
         objects = []
+        idx = 0
         for pr in prs:
+            idx += 1
             try:
                 objects.extend(extract_pr_objects(pr))
-            except Exception:
-                self.log.exception("Unable to extract PR data: %s" % pr)
+            except Exception as excpt:
+                raise ExtractPRIssue(excpt, pr, idx)
         return objects
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ flask
 flask_cors
 jsonschema
 pyyaml
+tenacity

--- a/tests/unit/test_crawler_gerrit.py
+++ b/tests/unit/test_crawler_gerrit.py
@@ -34,7 +34,7 @@ class TestGerritCrawler(unittest.TestCase):
         input_review, xtrd_ref = load_change(name)
 
         rf = review.ReviewesFetcher(base_url, None)
-        xtrd = rf.extract_objects([input_review])
+        xtrd = rf.extract_objects([input_review], print)
 
         ddiff = DeepDiff(xtrd_ref, xtrd, ignore_order=True)
         if ddiff:

--- a/tests/unit/test_crawler_github.py
+++ b/tests/unit/test_crawler_github.py
@@ -34,7 +34,7 @@ class TestGithubCrawler(unittest.TestCase):
         input_pr, xtrd_ref = load_change(name)
 
         pr_fetcher = pullrequest.PRsFetcher(None, 'https://github.com', None, None)
-        xtrd = pr_fetcher.extract_objects([input_pr])
+        xtrd = pr_fetcher.extract_objects([input_pr], print)
 
         ddiff = DeepDiff(xtrd_ref, xtrd, ignore_order=True)
         if ddiff:


### PR DESCRIPTION
- manage errors from github
- run a thread per Github token
- dump raw pr into the /var/lib/crawler if it exists
- manage empty authors as ghost
- retry multiple times if a graphql request fails