### PR TITLE
web: have a correct history of events in /change/ when filtered on authors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 ### Removed
 ### Fixed
 
+- [web] have a correct history of events in /change/ when filtered on authors (#136)
+
 ## [0.2] - 2020-04-24
 
 ### Added

--- a/web/src/components/change.js
+++ b/web/src/components/change.js
@@ -164,6 +164,7 @@ class Change extends BaseQueryComponent {
     this.state.name = 'changes_and_events'
     this.state.graph_type = 'changes_and_events'
     this.state.pageSize = 100
+    this.state.forceAllAuthors = true
   }
 
   componentDidMount () {

--- a/web/src/components/common.js
+++ b/web/src/components/common.js
@@ -103,7 +103,8 @@ class BaseQueryComponent extends React.Component {
       name: null, // must be set by sub-class
       graph_type: null, // must be set by sub-class
       pageSize: 10,
-      selectedPage: 0
+      selectedPage: 0,
+      forceAllAuthors: false // could be set by sub-class
     }
     this.handlePageChange.bind(this)
     this.queryBackend.bind(this)
@@ -127,7 +128,7 @@ class BaseQueryComponent extends React.Component {
       gte: params.get('gte'),
       lte: params.get('lte'),
       excludeAuthors: params.get('exclude_authors'),
-      authors: params.get('authors'),
+      authors: this.state.forceAllAuthors ? null : params.get('authors'),
       graph_type: this.state.graph_type,
       from: start * this.state.pageSize,
       size: this.state.pageSize,


### PR DESCRIPTION

closes #136